### PR TITLE
docs: expand explanatory comments across app

### DIFF
--- a/src/components/TimerItemForm.tsx
+++ b/src/components/TimerItemForm.tsx
@@ -18,8 +18,11 @@ export default function TimerItemForm({ value, onChange, onRemove }: Props) {
   const [seconds, setSeconds] = useState(value ? String(value.durationSec % 60) : '0');
   const [note, setNote] = useState(value?.note ?? '');
 
-  // 入力内容が変化した際に親へ値を返すヘルパー
-  const commit = () => {
+  /**
+   * 入力欄の内容をまとめて親コンポーネントへ通知する。
+   * 入力された分・秒から合計秒数を計算し、負値は0として扱う。
+   */
+  const commit = (): void => {
     const m = parseInt(minutes || '0', 10);
     const s = parseInt(seconds || '0', 10);
     onChange({ label, durationSec: Math.max(0, m * 60 + s), note });

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -11,8 +11,12 @@ import { Ionicons } from '@expo/vector-icons';
 
 // 画面下部に表示されるタブナビゲーションの設定
 
-const Tab = createBottomTabNavigator();
+const Tab = createBottomTabNavigator(); // ボトムタブナビゲーターを作成
 
+/**
+ * アプリ全体のルートタブナビゲーションを定義する。
+ * @returns ボトムタブ付きのナビゲーションコンポーネント
+ */
 export default function RootTabs() {
   return (
     <Tab.Navigator

--- a/src/screens/CreateScreen.tsx
+++ b/src/screens/CreateScreen.tsx
@@ -68,6 +68,7 @@ export default function CreateScreen({ route, navigation }: any) {
   const [showWeekdayPicker, setShowWeekdayPicker] = useState(false);
   const [tempWeekday, setTempWeekday] = useState(0);
 
+  // 画面で使用するすべての入力状態を初期化する
   const reset = () => {
     setStage('choose');
     setSetName('');
@@ -97,11 +98,13 @@ export default function CreateScreen({ route, navigation }: any) {
     navigation.setParams({ editId: undefined });
   };
 
+  // 編集を取りやめてタイマー一覧へ戻る
   const handleCancel = () => {
     reset();
     navigation.navigate('タイマー一覧');
   };
 
+  // 指定した入力欄が画面中央付近にくるようスクロールする
   const scrollToInput = (target: number) => {
     const scrollHandle = findNodeHandle(scrollRef.current);
     if (!scrollHandle) return;
@@ -118,21 +121,25 @@ export default function CreateScreen({ route, navigation }: any) {
     );
   };
 
+  // 時刻ピッカーで選択された時間を確定
   const confirmTimePicker = () => {
     setNotifyTime(tempNotifyTime);
     setShowTimePicker(false);
   };
 
+  // 繰り返し間隔の単位を確定
   const confirmRepeatUnit = () => {
     setRepeatUnit(tempRepeatUnit);
     setShowRepeatUnitPicker(false);
   };
 
+  // 月間繰り返しで指定した第n週を確定
   const confirmNthWeek = () => {
     setRepeatNthWeek(tempNthWeek);
     setShowNthWeekPicker(false);
   };
 
+  // 繰り返しの曜日を確定
   const confirmWeekday = () => {
     setRepeatNthWeekday(tempWeekday);
     setShowWeekdayPicker(false);
@@ -146,6 +153,7 @@ export default function CreateScreen({ route, navigation }: any) {
     year: '年',
   };
 
+  // 画面の状態に応じてヘッダータイトルや戻るボタンを設定
   useEffect(() => {
     let title = '作成';
     if (stage === 'newInfo' || stage === 'newTimers') {
@@ -172,16 +180,19 @@ export default function CreateScreen({ route, navigation }: any) {
     });
   }, [stage, setName, selectedId, state.timerSets, navigation, route?.params?.editId]);
 
+  // 新規タイマーセット作成フローを開始
   const toNewInfo = () => {
     reset();
     setStage('newInfo');
   };
 
+  // 既存タイマーセットの編集フローを開始
   const toSelectExisting = () => {
     reset();
     setStage('selectExisting');
   };
 
+  // セット名入力後にタイマー入力段階へ進む
   const startNewTimers = () => {
     if (!setName.trim()) {
       Alert.alert('作成できません', 'セット名を入力してください。');
@@ -191,6 +202,7 @@ export default function CreateScreen({ route, navigation }: any) {
     setStage('newTimers');
   };
 
+  // 編集対象の既存タイマーセットを読み込む
   const selectExisting = (id: string) => {
     const set = state.timerSets.find(s => s.id === id);
     if (!set) return;
@@ -242,6 +254,7 @@ export default function CreateScreen({ route, navigation }: any) {
     setStage('existingTimers');
   };
 
+  // タイマー入力の特定フィールドを更新する
   const updateTimer = (
     index: number,
     field: 'label' | 'min' | 'sec' | 'notify',
@@ -252,9 +265,11 @@ export default function CreateScreen({ route, navigation }: any) {
     );
   };
 
+  // 新しいタイマー入力行を追加
   const addTimerRow = () =>
     setTimers(prev => [...prev, { label: '', min: '', sec: '', notify: true }]);
 
+  // 新規にタイマーセットを保存
   const saveNew = async () => {
     const parsed = timers
       .map((t, i) => {
@@ -314,6 +329,7 @@ export default function CreateScreen({ route, navigation }: any) {
     navigation.goBack();
   };
 
+  // 既存タイマーセットの変更を保存
   const saveExisting = async () => {
     const target = state.timerSets.find(s => s.id === selectedId);
     if (!target) return;
@@ -374,6 +390,7 @@ export default function CreateScreen({ route, navigation }: any) {
     navigation.goBack();
   };
 
+  // 複数のタイマー入力フォームを描画
   const renderTimerRows = () => (
     <View>
       {timers.map((t, idx) => (

--- a/src/screens/DataManagementScreen.tsx
+++ b/src/screens/DataManagementScreen.tsx
@@ -20,6 +20,7 @@ export default function DataManagementScreen() {
     });
   }, [navigation]);
 
+  // 履歴から削除されたタイマーセットの候補を抽出
   const deletedSets = useMemo(() => {
     const existing = new Map(state.timerSets.map(s => [s.id, s.name]));
     const map = new Map<string, string>();
@@ -31,7 +32,12 @@ export default function DataManagementScreen() {
     return Array.from(map.entries()).map(([id, name]) => ({ id, name }));
   }, [state.history, state.timerSets]);
 
-  const toggleHidden = (id: string, hidden: boolean) => {
+  /**
+   * 特定のタイマーセットをホーム画面で非表示にするかどうかを切り替える。
+   * @param id 対象タイマーセットのID
+   * @param hidden trueなら非表示リストへ追加する
+   */
+  const toggleHidden = (id: string, hidden: boolean): void => {
     let next = state.hiddenTimerSetIds;
     if (hidden) {
       next = [...next, id];

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -30,8 +30,13 @@ dayjs.extend(weekOfYear);
 
 type Range = '日' | '週';
 
-// 徐々に白に近づけることで色を薄くするユーティリティ関数
-const lighten = (hex: string, factor: number) => {
+/**
+ * 渡された16進カラーコードを指定割合だけ白に近づけて明るくする。
+ * @param hex ベースとなるカラーコード（例: "#00FF00"）
+ * @param factor 0〜1の割合。1に近いほど白に近づく。
+ * @returns 明度を調整したカラーコード
+ */
+const lighten = (hex: string, factor: number): string => {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
@@ -51,6 +56,7 @@ export default function HistoryScreen() {
   const [month, setMonth] = useState(now.month() + 1);
   const [showPicker, setShowPicker] = useState(false);
 
+  // フィルタ済みの履歴エントリをメモ化して取得
   const visibleHistory = useMemo(
     () =>
       state.history.filter(
@@ -62,6 +68,7 @@ export default function HistoryScreen() {
     [state.history, state.hiddenTimerSetIds],
   );
 
+  // 総時間や平均時間などの統計情報を計算
   const stats = useMemo(() => {
     const entries = visibleHistory;
     const totalSec = entries.reduce((s, h) => s + h.totalDurationSec, 0);
@@ -77,6 +84,7 @@ export default function HistoryScreen() {
     return { totalSec, sessions, avgMin, streak };
   }, [visibleHistory]);
 
+  // グラフ描画のために時間をバケット集計
   const chartInfo = useMemo(() => {
     const history = visibleHistory;
     const buckets: Record<string, number> = {};
@@ -140,6 +148,7 @@ export default function HistoryScreen() {
   const chartWidth =
     chartData.length * (BAR_WIDTH + BAR_GAP) + chartPaddingRight + BAR_GAP;
 
+  // タイマーセットごとの使用時間を集計
   const usageInfo = useMemo(() => {
     const entries = visibleHistory.filter(h => {
       const d = dayjs(h.completedAt!);
@@ -164,6 +173,7 @@ export default function HistoryScreen() {
   }, [visibleHistory, state.timerSets, usageRange, year, month]);
 
 
+  // 一定の継続日数に達した場合にお祝いメッセージを表示
   useEffect(() => {
     const milestones = [1, 2, 3, 5, 7, 10, 15, 20, 25, 30];
     const isMilestone =

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -8,7 +8,7 @@ import { Ionicons } from '@expo/vector-icons';
 // 設定画面。通知関連の設定やデータ管理画面への遷移を提供する。
 
 export default function SettingsScreen({ navigation }: any) {
-  const { state, dispatch } = useTimerState();
+  const { state, dispatch } = useTimerState(); // 現在の設定値と更新用dispatchを取得
 
   return (
     <ScrollView style={styles.container}>

--- a/src/types/datetimepicker.d.ts
+++ b/src/types/datetimepicker.d.ts
@@ -2,11 +2,11 @@
 declare module '@react-native-community/datetimepicker' {
   import * as React from 'react';
   export interface DateTimePickerProps {
-    value: Date;
-    mode?: 'date' | 'time';
-    display?: 'default' | 'spinner' | 'calendar' | 'inline';
-    onChange: (event: any, date?: Date) => void;
-    locale?: string;
+    value: Date; // 現在選択されている日時
+    mode?: 'date' | 'time'; // 日付・時間どちらを選択するか
+    display?: 'default' | 'spinner' | 'calendar' | 'inline'; // 表示スタイル
+    onChange: (event: any, date?: Date) => void; // 日時が変更されたときのハンドラ
+    locale?: string; // ロケール設定
   }
   export default class DateTimePicker extends React.Component<DateTimePickerProps> {}
 }

--- a/src/types/picker.d.ts
+++ b/src/types/picker.d.ts
@@ -2,14 +2,14 @@
 declare module '@react-native-picker/picker' {
   import * as React from 'react';
   export interface PickerProps {
-    selectedValue?: any;
-    onValueChange?: (itemValue: any, itemIndex: number) => void;
-    style?: any;
-    itemStyle?: any;
-    children?: React.ReactNode;
+    selectedValue?: any; // 現在選択されている値
+    onValueChange?: (itemValue: any, itemIndex: number) => void; // 選択が変わった際のハンドラ
+    style?: any; // Picker全体のスタイル
+    itemStyle?: any; // 各アイテムのスタイル
+    children?: React.ReactNode; // Picker.Item などの子要素
   }
   export class Picker extends React.Component<PickerProps> {
-    static Item: React.ComponentType<{ label: string; value: any }>;
+    static Item: React.ComponentType<{ label: string; value: any }>; // 個々の選択肢を表すコンポーネント
   }
   export default Picker;
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,11 +1,19 @@
-// 2桁になるようゼロ埋めするユーティリティ関数
-export const pad2 = (n: number) => {
+/**
+ * 与えられた数値を2桁にゼロ埋めして文字列化する。
+ * @param n 変換対象の数値。有限でない場合は0として扱う。
+ * @returns 先頭を0で埋めた2桁以上の文字列。
+ */
+export const pad2 = (n: number): string => {
   const safe = Number.isFinite(n) ? n : 0;
   return safe.toString().padStart(2, '0');
 };
 
-// 秒数を「HH:MM:SS」または「MM:SS」形式の文字列に変換
-export const formatHMS = (sec: number) => {
+/**
+ * 秒数を人間が読みやすい "HH:MM:SS" もしくは "MM:SS" 形式へ変換する。
+ * @param sec 表示したい時間（秒）。負の値や非数は0として扱う。
+ * @returns フォーマット済みの時間文字列。
+ */
+export const formatHMS = (sec: number): string => {
   const s = Number.isFinite(sec) ? Math.max(0, Math.floor(sec)) : 0;
   const h = Math.floor(s / 3600);
   const m = Math.floor((s % 3600) / 60);

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,7 +1,12 @@
-// 簡易的な UUID v4 を生成する関数
+/**
+ * RFC4122に準拠した簡易的な UUID v4 を生成する。
+ * 内部では16進数のテンプレート文字列をランダム値で置き換える。
+ * @returns ランダムな一意識別子（UUID）。
+ */
 export function uuidv4(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
     const r = Math.random() * 16 | 0;
+    // y 部分は RFC4122 の仕様に従い 8,9,A,B のいずれかとなる
     const v = c === 'x' ? r : (r & 0x3 | 0x8);
     return v.toString(16);
   });


### PR DESCRIPTION
## Summary
- detail pad2/formatHMS and uuid utilities with JSDoc annotations
- clarify notification helpers and timer runner logic with return and effect notes
- document context provider, navigation root, and data-management toggles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b004d850bc832ab67f08b10b4956f2