### PR TITLE
fix: remove stray text in IconButton

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -46,8 +46,15 @@ export default function IconButton({
         style, // 外部から渡された追加スタイル
       ]}
     >
-      <Ionicons name={icon} size={20} color={textColor} style={{ marginRight: 6 }} /> {/* アイコン表示 */}
-      <Text style={[styles.txt, { color: textColor }]} numberOfLines={1}>{label}</Text> {/* ラベル表示 */}
+      <Ionicons
+        name={icon}
+        size={20}
+        color={textColor}
+        style={{ marginRight: 6 }}
+      />
+      <Text style={[styles.txt, { color: textColor }]} numberOfLines={1}>
+        {label}
+      </Text>
     </Pressable>
   );
 }


### PR DESCRIPTION
## Summary
- avoid raw text nodes in IconButton to stop `<Text>` warning

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1a3be639c832ab52665465b2893b5