### PR TITLE
fix: avoid raw text in pressable

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'; // React本体をインポート
-import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native'; // ボタンやテキストなどのUI要素
+import { Pressable, Text, StyleSheet, ViewStyle, View } from 'react-native'; // ボタンやテキストなどのUI要素
 import { Ionicons } from '@expo/vector-icons'; // アイコンフォントを提供するライブラリ
 import { Colors } from '../constants/colors'; // 共通で利用するカラー定数
 
@@ -46,22 +46,22 @@ export default function IconButton({
         style, // 外部から渡された追加スタイル
       ]}
     >
-      <Ionicons
-        name={icon}
-        size={20}
-        color={textColor}
-        style={{ marginRight: 6 }}
-      />
-      <Text style={[styles.txt, { color: textColor }]} numberOfLines={1}>
-        {label}
-      </Text>
+      <View style={styles.content}>
+        <Ionicons
+          name={icon}
+          size={20}
+          color={textColor}
+          style={{ marginRight: 6 }}
+        />
+        <Text style={[styles.txt, { color: textColor }]} numberOfLines={1}>
+          {label}
+        </Text>
+      </View>
     </Pressable>
   );
 }
 const styles = StyleSheet.create({ // コンポーネントで使用するスタイル定義
   btn: { // ボタン全体のスタイル
-    flexDirection: 'row', // アイコンとテキストを横並びに配置
-    alignItems: 'center', // 垂直方向で中央揃え
     paddingHorizontal: 14, // 左右の余白
     paddingVertical: 10, // 上下の余白
     borderRadius: 12, // 角の丸み
@@ -70,6 +70,10 @@ const styles = StyleSheet.create({ // コンポーネントで使用するスタ
     shadowOffset: { width: 0, height: 2 }, // 影の位置
     shadowRadius: 4, // 影のぼかし半径
     elevation: 2, // Androidでの影の高さ
+  },
+  content: { // アイコンとテキストを横並びに配置
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   txt: { fontWeight: '700' }, // ボタンラベルを太字にする
   disabled: { opacity: 0.5 }, // 無効化時は半透明にする

--- a/src/screens/TimerListScreen.tsx
+++ b/src/screens/TimerListScreen.tsx
@@ -10,7 +10,8 @@ export default function TimerListScreen({ navigation }: any) { // タイマー�
   const { state, dispatch } = useTimerState(); // 状態と操作関数を取得
 
   return ( // 画面描画
-    <View style={styles.container}> {/* 全体を包むコンテナ */}
+    <View style={styles.container}>
+      {/* 登録済みタイマーセットの一覧 */}
       <FlatList
         contentContainerStyle={{ padding: 16 }} // リスト全体の余白
         data={state.timerSets} // 表示するタイマーセット配列
@@ -42,11 +43,16 @@ export default function TimerListScreen({ navigation }: any) { // タイマー�
           /> // TimerSetCard終わり
         )} // renderItem終わり
         ListEmptyComponent={
-          <Text style={{ color: Colors.subText }}>まだタイマーセットがありません。右下の⊕から追加しましょう。</Text>
+          <Text style={{ color: Colors.subText }}>
+            まだタイマーセットがありません。右下の⊕から追加しましょう。
+          </Text>
         } // データが空のときの表示
-      /> {/* FlatList終わり */}
-      <Pressable style={styles.fab} onPress={() => navigation.navigate('作成', { editId: undefined })}> {/* 追加ボタン */}
-        <Ionicons name="add-circle" size={64} color={Colors.primary} /> {/* 追加アイコン */}
+      />
+      <Pressable
+        style={styles.fab}
+        onPress={() => navigation.navigate('作成', { editId: undefined })}
+      >
+        <Ionicons name="add-circle" size={64} color={Colors.primary} />
       </Pressable>
     </View>
   ); // return終端


### PR DESCRIPTION
## Summary
- avoid stray text nodes in timer list screen
- wrap IconButton contents inside a view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b1a75571f8832a84c8b4e7e0ef04a2