### PR TITLE
feat: enable PiP timer controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.76.9",
     "react-native-gesture-handler": "~2.20.2",
+    "react-native-pip-android": "^1.2.0",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",

--- a/src/components/TimerRunner.tsx
+++ b/src/components/TimerRunner.tsx
@@ -7,6 +7,7 @@ import { Audio } from 'expo-av';
 import { useTimerState } from '../context/TimerContext';
 import { SOUND_FILES } from '../constants/sounds';
 import { scheduleEndNotification } from '../utils/notifications';
+import { usePipTimerControls } from '../utils/pip';
 
 // 複数のタイマーを連続で実行するランナーコンポーネント。
 // カウントダウン処理や音声再生、通知のスケジュールなどを管理する。
@@ -276,6 +277,14 @@ export default function TimerRunner({ timerSet, onFinish, onCancel }: Props) {
     try { notifySoundRef.current?.stopAsync(); } catch {}
     onCancel?.();
   };
+
+  // Enable PiP controls when app goes to background
+  usePipTimerControls({
+    start,
+    stop: pause,
+    reset: resetCurrent,
+    selectType: skip,
+  });
 
   return (
     <View style={styles.container}>

--- a/src/utils/pip.ts
+++ b/src/utils/pip.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { AppState, DeviceEventEmitter } from 'react-native';
+import PipHandler from 'react-native-pip-android';
+
+export type PipHandlers = {
+  start?: () => void;
+  stop?: () => void;
+  reset?: () => void;
+  selectType?: () => void;
+};
+
+/**
+ * Manage entering Picture in Picture mode and handle actions from PiP controls.
+ */
+export const usePipTimerControls = (handlers: PipHandlers) => {
+  useEffect(() => {
+    const appStateSub = AppState.addEventListener('change', state => {
+      if (state === 'background') {
+        try {
+          PipHandler.enterPictureInPictureMode?.(300, 214, [
+            { id: 'start', title: '開始' },
+            { id: 'stop', title: '停止' },
+            { id: 'reset', title: 'リセット' },
+            { id: 'select', title: '種類' },
+          ]);
+        } catch (e) {
+          // noop
+        }
+      } else if (state === 'active') {
+        try { PipHandler.exitPictureInPictureMode?.(); } catch {}
+      }
+    });
+
+    const pipEvent = DeviceEventEmitter.addListener('onPipAction', (e: any) => {
+      switch (e?.id || e?.name || e?.action) {
+        case 'start':
+          handlers.start?.();
+          break;
+        case 'stop':
+          handlers.stop?.();
+          break;
+        case 'reset':
+          handlers.reset?.();
+          break;
+        case 'select':
+          handlers.selectType?.();
+          break;
+      }
+    });
+
+    return () => {
+      appStateSub.remove();
+      pipEvent.remove();
+    };
+  }, [handlers]);
+};

--- a/types/react-native-pip-android.d.ts
+++ b/types/react-native-pip-android.d.ts
@@ -1,0 +1,14 @@
+declare module 'react-native-pip-android' {
+  interface PipAction {
+    id: string;
+    title: string;
+    icon?: any;
+  }
+  function enterPictureInPictureMode(width?: number, height?: number, actions?: PipAction[]): void;
+  function exitPictureInPictureMode(): void;
+  const PipHandler: {
+    enterPictureInPictureMode: typeof enterPictureInPictureMode;
+    exitPictureInPictureMode: typeof exitPictureInPictureMode;
+  };
+  export default PipHandler;
+}


### PR DESCRIPTION
## Summary
- allow timer controls from Android picture-in-picture
- expose reusable hook to manage PiP state/actions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1ab086a78832a92a2abcf9531ff92