### PR TITLE
fix: guard pip feature on non-android platforms

### DIFF
--- a/src/utils/pip.android.ts
+++ b/src/utils/pip.android.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { AppState, DeviceEventEmitter } from 'react-native';
+import PipHandler from 'react-native-pip-android';
+
+export type PipHandlers = {
+  start?: () => void;
+  stop?: () => void;
+  reset?: () => void;
+  selectType?: () => void;
+};
+
+const ACTIONS = [
+  { id: 'start', title: '開始' },
+  { id: 'stop', title: '停止' },
+];
+
+/**
+ * Enter Android Picture-in-Picture mode with predefined timer controls.
+ */
+export const enterPipMode = () => {
+  try {
+    PipHandler.enterPictureInPictureMode?.(300, 214, ACTIONS);
+  } catch {
+    // ignore errors
+  }
+};
+
+/**
+ * Track whether the app is currently in Picture in Picture mode.
+ * Returns a boolean state and a helper to manually enter PiP.
+ */
+export const usePipMode = () => {
+  const [inPip, setInPip] = useState(false);
+
+  useEffect(() => {
+    const appStateSub = AppState.addEventListener('change', state => {
+      if (state === 'active') {
+        setInPip(false);
+      } else if (state === 'background') {
+        setInPip(true);
+      }
+    });
+
+    const enterSub = DeviceEventEmitter.addListener('onPipEnter', () => setInPip(true));
+    const exitSub = DeviceEventEmitter.addListener('onPipExit', () => setInPip(false));
+
+    return () => {
+      appStateSub.remove();
+      enterSub.remove();
+      exitSub.remove();
+    };
+  }, []);
+
+  const manualEnter = () => {
+    enterPipMode();
+    setInPip(true);
+  };
+
+  return { inPip, enterPip: manualEnter } as const;
+};
+
+/**
+ * Manage entering Picture in Picture mode and handle actions from PiP controls.
+ */
+export const usePipTimerControls = (handlers: PipHandlers) => {
+  useEffect(() => {
+    const appStateSub = AppState.addEventListener('change', state => {
+      if (state === 'background') {
+        enterPipMode();
+      } else if (state === 'active') {
+        try { PipHandler.exitPictureInPictureMode?.(); } catch {}
+      }
+    });
+
+    const pipEvent = DeviceEventEmitter.addListener('onPipAction', (e: any) => {
+      switch (e?.id || e?.name || e?.action) {
+        case 'start':
+          handlers.start?.();
+          break;
+        case 'stop':
+          handlers.stop?.();
+          break;
+        case 'reset':
+          handlers.reset?.();
+          break;
+        case 'select':
+          handlers.selectType?.();
+          break;
+      }
+    });
+
+    return () => {
+      appStateSub.remove();
+      pipEvent.remove();
+    };
+  }, [handlers]);
+};

--- a/src/utils/pip.ts
+++ b/src/utils/pip.ts
@@ -1,7 +1,3 @@
-import { useEffect, useState } from 'react';
-import { AppState, DeviceEventEmitter } from 'react-native';
-import PipHandler from 'react-native-pip-android';
-
 export type PipHandlers = {
   start?: () => void;
   stop?: () => void;
@@ -9,89 +5,11 @@ export type PipHandlers = {
   selectType?: () => void;
 };
 
-const ACTIONS = [
-  { id: 'start', title: '開始' },
-  { id: 'stop', title: '停止' },
-];
+// No-op implementation for non-Android platforms
+export const enterPipMode = () => {};
 
-/**
- * Enter Android Picture-in-Picture mode with predefined timer controls.
- */
-export const enterPipMode = () => {
-  try {
-    PipHandler.enterPictureInPictureMode?.(300, 214, ACTIONS);
-  } catch {
-    // ignore errors
-  }
-};
-
-/**
- * Track whether the app is currently in Picture in Picture mode.
- * Returns a boolean state and a helper to manually enter PiP.
- */
 export const usePipMode = () => {
-  const [inPip, setInPip] = useState(false);
-
-  useEffect(() => {
-    const appStateSub = AppState.addEventListener('change', state => {
-      if (state === 'active') {
-        setInPip(false);
-      } else if (state === 'background') {
-        setInPip(true);
-      }
-    });
-
-    const enterSub = DeviceEventEmitter.addListener('onPipEnter', () => setInPip(true));
-    const exitSub = DeviceEventEmitter.addListener('onPipExit', () => setInPip(false));
-
-    return () => {
-      appStateSub.remove();
-      enterSub.remove();
-      exitSub.remove();
-    };
-  }, []);
-
-  const manualEnter = () => {
-    enterPipMode();
-    setInPip(true);
-  };
-
-  return { inPip, enterPip: manualEnter } as const;
+  return { inPip: false, enterPip: () => {} } as const;
 };
 
-/**
- * Manage entering Picture in Picture mode and handle actions from PiP controls.
- */
-export const usePipTimerControls = (handlers: PipHandlers) => {
-  useEffect(() => {
-    const appStateSub = AppState.addEventListener('change', state => {
-      if (state === 'background') {
-        enterPipMode();
-      } else if (state === 'active') {
-        try { PipHandler.exitPictureInPictureMode?.(); } catch {}
-      }
-    });
-
-    const pipEvent = DeviceEventEmitter.addListener('onPipAction', (e: any) => {
-      switch (e?.id || e?.name || e?.action) {
-        case 'start':
-          handlers.start?.();
-          break;
-        case 'stop':
-          handlers.stop?.();
-          break;
-        case 'reset':
-          handlers.reset?.();
-          break;
-        case 'select':
-          handlers.selectType?.();
-          break;
-      }
-    });
-
-    return () => {
-      appStateSub.remove();
-      pipEvent.remove();
-    };
-  }, [handlers]);
-};
+export const usePipTimerControls = (_handlers: PipHandlers) => {};


### PR DESCRIPTION
## Summary
- move PiP utilities into Android-specific module
- provide no-op PiP implementation for other platforms to avoid bundler errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1b2ab8628832a9f02efd766853607