### PR TITLE
fix: remove invalid pip plugin config

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,8 +29,7 @@
     },
     "plugins": [
       "expo-notifications",
-      "expo-font",
-      "react-native-pip-android"
+      "expo-font"
     ],
     "useNextNotificationsApi": true,
     "notification": {


### PR DESCRIPTION
## Summary
- remove `react-native-pip-android` from Expo plugins to avoid plugin resolution errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1b7050044832a8e36df13be515fc0