### PR TITLE
feat: add PiP support for iOS and web

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-native": "0.76.9",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-pip-android": "^1.2.0",
+    "react-native-pip-iphone": "^1.2.0",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",

--- a/src/components/TimerRunner.tsx
+++ b/src/components/TimerRunner.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, Pressable, AppState } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
 import { Timer, TimerSet } from '../context/TimerContext';
 import { Colors } from '../constants/colors';
 import { formatHMS } from '../utils/format';
@@ -7,7 +8,7 @@ import { Audio } from 'expo-av';
 import { useTimerState } from '../context/TimerContext';
 import { SOUND_FILES } from '../constants/sounds';
 import { scheduleEndNotification } from '../utils/notifications';
-import { usePipTimerControls } from '../utils/pip';
+import { usePipMode, usePipTimerControls } from '../utils/pip';
 
 // 複数のタイマーを連続で実行するランナーコンポーネント。
 // カウントダウン処理や音声再生、通知のスケジュールなどを管理する。
@@ -44,6 +45,7 @@ export default function TimerRunner({ timerSet, onFinish, onCancel }: Props) {
 
   const totalCount = timerSet.timers.length; // タイマーの総数
   const current = timerSet.timers[index];    // 現在のタイマー
+  const { enterPip } = usePipMode();
 
   useEffect(() => {
     indexRef.current = index;
@@ -288,6 +290,13 @@ export default function TimerRunner({ timerSet, onFinish, onCancel }: Props) {
 
   return (
     <View style={styles.container}>
+      <Pressable onPress={enterPip} style={styles.pipBtn}>
+        <MaterialIcons
+          name="picture-in-picture-alt"
+          size={24}
+          color={Colors.text}
+        />
+      </Pressable>
       {/* セット名と現在のタイマー情報 */}
       <Text style={styles.name}>{timerSet.name}</Text>
       <Text style={styles.currentLabel}>{current?.label ?? '—'}</Text>
@@ -320,7 +329,17 @@ export default function TimerRunner({ timerSet, onFinish, onCancel }: Props) {
 
 // このコンポーネントで利用するスタイル定義
 const styles = StyleSheet.create({
-  container: { alignItems: 'center', padding: 20 },
+  container: { alignItems: 'center', padding: 20, width: '100%', position: 'relative' },
+  pipBtn: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    padding: 6,
+    borderRadius: 16,
+    backgroundColor: Colors.card,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
   name: { fontSize: 20, fontWeight: '700', color: Colors.text },
   currentLabel: { marginTop: 12, fontSize: 16, color: Colors.subText },
   time: { fontSize: 72, fontWeight: '800', color: Colors.primaryDark, marginVertical: 20 },

--- a/src/utils/pip.ios.ts
+++ b/src/utils/pip.ios.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { AppState } from 'react-native';
+import PipHandler from 'react-native-pip-iphone';
+
+export type PipHandlers = {
+  start?: () => void;
+  stop?: () => void;
+  reset?: () => void;
+  selectType?: () => void;
+};
+
+/**
+ * Enter iOS Picture in Picture mode.
+ */
+export const enterPipMode = () => {
+  try {
+    PipHandler.enterPictureInPicture?.();
+  } catch {
+    // ignore errors
+  }
+};
+
+/**
+ * Track whether the app is currently in Picture in Picture mode.
+ */
+export const usePipMode = () => {
+  const [inPip, setInPip] = useState(false);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', state => {
+      setInPip(state !== 'active');
+    });
+    return () => sub.remove();
+  }, []);
+
+  const manualEnter = () => {
+    enterPipMode();
+    setInPip(true);
+  };
+
+  return { inPip, enterPip: manualEnter } as const;
+};
+
+/**
+ * Manage entering Picture in Picture when the app goes to background.
+ */
+export const usePipTimerControls = (_handlers: PipHandlers) => {
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', state => {
+      if (state === 'background') {
+        enterPipMode();
+      }
+    });
+    return () => sub.remove();
+  }, [_handlers]);
+};
+

--- a/src/utils/pip.ts
+++ b/src/utils/pip.ts
@@ -5,7 +5,7 @@ export type PipHandlers = {
   selectType?: () => void;
 };
 
-// No-op implementation for non-Android platforms
+// Fallback no-op implementation for platforms without PiP support
 export const enterPipMode = () => {};
 
 export const usePipMode = () => {

--- a/src/utils/pip.web.ts
+++ b/src/utils/pip.web.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+
+export type PipHandlers = {
+  start?: () => void;
+  stop?: () => void;
+  reset?: () => void;
+  selectType?: () => void;
+};
+
+/**
+ * Enter web Picture in Picture mode using the first video element.
+ */
+export const enterPipMode = () => {
+  try {
+    const video = document.querySelector('video') as any;
+    if (video && video.requestPictureInPicture) {
+      video.requestPictureInPicture();
+    }
+  } catch {
+    // ignore errors
+  }
+};
+
+/**
+ * Track whether the page is in Picture in Picture mode.
+ */
+export const usePipMode = () => {
+  const [inPip, setInPip] = useState(false);
+
+  useEffect(() => {
+    const onEnter = () => setInPip(true);
+    const onLeave = () => setInPip(false);
+
+    document.addEventListener('enterpictureinpicture', onEnter as any);
+    document.addEventListener('leavepictureinpicture', onLeave as any);
+
+    return () => {
+      document.removeEventListener('enterpictureinpicture', onEnter as any);
+      document.removeEventListener('leavepictureinpicture', onLeave as any);
+    };
+  }, []);
+
+  return { inPip, enterPip: enterPipMode } as const;
+};
+
+/**
+ * Enter Picture in Picture when the tab becomes hidden.
+ */
+export const usePipTimerControls = (_handlers: PipHandlers) => {
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.hidden) {
+        enterPipMode();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [_handlers]);
+};
+

--- a/types/react-native-pip-iphone.d.ts
+++ b/types/react-native-pip-iphone.d.ts
@@ -1,0 +1,10 @@
+declare module 'react-native-pip-iphone' {
+  function enterPictureInPicture(): void;
+  function exitPictureInPicture(): void;
+  const PipHandler: {
+    enterPictureInPicture: typeof enterPictureInPicture;
+    exitPictureInPicture: typeof exitPictureInPicture;
+  };
+  export default PipHandler;
+}
+


### PR DESCRIPTION
## Summary
- allow iOS timer views to enter native PiP
- enable web builds to switch to Picture in Picture when hidden
- clarify fallback PiP utilities for unsupported platforms
- add icon-only PiP button to timer view

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1b961a4c4832aa118942f3b92ff31