### PR TITLE
feat: add PiP timer layout

### DIFF
--- a/src/components/TimerRunner.tsx
+++ b/src/components/TimerRunner.tsx
@@ -45,7 +45,7 @@ export default function TimerRunner({ timerSet, onFinish, onCancel }: Props) {
 
   const totalCount = timerSet.timers.length; // タイマーの総数
   const current = timerSet.timers[index];    // 現在のタイマー
-  const { enterPip } = usePipMode();
+  const { inPip, enterPip } = usePipMode();
 
   useEffect(() => {
     indexRef.current = index;
@@ -288,6 +288,30 @@ export default function TimerRunner({ timerSet, onFinish, onCancel }: Props) {
     selectType: skip,
   });
 
+  if (inPip) {
+    return (
+      <View style={pipStyles.container}>
+        <Text style={pipStyles.name}>{timerSet.name}</Text>
+        <Text style={pipStyles.current}>{current?.label ?? '—'}</Text>
+        <Text style={pipStyles.time}>{formatHMS(remaining)}</Text>
+        <View style={pipStyles.controls}>
+          {!running ? (
+            <Pressable onPress={start} style={[pipStyles.btn, pipStyles.primary]}>
+              <Text style={pipStyles.btnText}>開始</Text>
+            </Pressable>
+          ) : (
+            <Pressable onPress={pause} style={[pipStyles.btn, pipStyles.secondary]}>
+              <Text style={pipStyles.btnText}>停止</Text>
+            </Pressable>
+          )}
+          <Pressable onPress={skip} style={[pipStyles.btn, pipStyles.secondary]}>
+            <Text style={pipStyles.btnText}>スキップ</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <Pressable onPress={enterPip} style={styles.pipBtn}>
@@ -350,4 +374,27 @@ const styles = StyleSheet.create({
   danger: { backgroundColor: Colors.danger },
   btnText: { color: '#0B1D2A', fontWeight: '700' },
   progress: { marginTop: 10, color: Colors.subText }
+});
+
+const pipStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 12,
+  },
+  name: { fontSize: 16, fontWeight: '700', color: Colors.text },
+  current: { fontSize: 14, color: Colors.subText, marginTop: 4 },
+  time: {
+    fontSize: 48,
+    fontWeight: '800',
+    color: Colors.primaryDark,
+    marginVertical: 12,
+  },
+  controls: { flexDirection: 'row', gap: 12, marginTop: 8 },
+  btn: { paddingVertical: 8, paddingHorizontal: 16, borderRadius: 12 },
+  primary: { backgroundColor: Colors.primary },
+  secondary: { backgroundColor: Colors.card, borderWidth: 1, borderColor: Colors.border },
+  btnText: { color: '#0B1D2A', fontWeight: '700' },
 });

--- a/src/utils/pip.android.ts
+++ b/src/utils/pip.android.ts
@@ -36,8 +36,6 @@ export const usePipMode = () => {
     const appStateSub = AppState.addEventListener('change', state => {
       if (state === 'active') {
         setInPip(false);
-      } else if (state === 'background') {
-        setInPip(true);
       }
     });
 
@@ -53,7 +51,6 @@ export const usePipMode = () => {
 
   const manualEnter = () => {
     enterPipMode();
-    setInPip(true);
   };
 
   return { inPip, enterPip: manualEnter } as const;

--- a/src/utils/pip.ios.ts
+++ b/src/utils/pip.ios.ts
@@ -43,7 +43,6 @@ export const usePipMode = () => {
 
   const manualEnter = () => {
     enterPipMode();
-    setInPip(true);
   };
 
   return { inPip, enterPip: manualEnter } as const;


### PR DESCRIPTION
## Summary
- render compact timer UI when in picture-in-picture mode
- add styles and controls for PiP window
- rely on OS PiP events before switching layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'react', 'react-native'; 'expo/tsconfig.base' not found)*
- `npm install` *(fails: 403 Forbidden for @expo/metro-runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fa6e758c832aa9543b2c1c2f79a1