### PR TITLE
feat: use expo notifications for timer controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "expo-av": "~15.0.2",
     "expo-font": "~13.0.4",
     "expo-notifications": "~0.29.14",
+    "expo-intent-launcher": "~10.5.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.9",

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -18,6 +18,14 @@ import { Ionicons } from '@expo/vector-icons';
 import Svg, { Circle, G } from 'react-native-svg';
 import { SOUND_OPTIONS, SOUND_FILES } from '../constants/sounds';
 import { Audio } from 'expo-av';
+import * as IntentLauncher from 'expo-intent-launcher';
+import {
+  initTimerNotification,
+  registerTimerActionHandler,
+  unregisterTimerActionHandler,
+  updateTimerNotification,
+  clearTimerNotification,
+} from '../utils/timerNotification';
 
 // ホーム画面。選択したタイマーセットの実行や簡易タイマーの操作を提供する。
 
@@ -408,6 +416,11 @@ export default function HomeScreen() {
     lastUpdateRef.current = Date.now();
     endTimeRef.current = Date.now() + rem * 1000;
     setRunning(true);
+    updateTimerNotification(
+      selectedSet ? selectedSet.name : '"クイックタイマー"',
+      selectedSet ? selectedSet.timers[indexRef.current]?.label ?? '' : '',
+      rem,
+    );
     intervalRef.current = setInterval(() => {
       if (endTimeRef.current == null) return;
       const left = Math.ceil((endTimeRef.current - Date.now()) / 1000);
@@ -416,8 +429,18 @@ export default function HomeScreen() {
         intervalRef.current = null;
         endTimeRef.current = null;
         setRemaining(0);
+        updateTimerNotification(
+          selectedSet ? selectedSet.name : '"クイックタイマー"',
+          selectedSet ? selectedSet.timers[indexRef.current]?.label ?? '' : '',
+          0,
+        );
       } else {
         setRemaining(left);
+        updateTimerNotification(
+          selectedSet ? selectedSet.name : '"クイックタイマー"',
+          selectedSet ? selectedSet.timers[indexRef.current]?.label ?? '' : '',
+          left,
+        );
       }
     }, 1000);
   };
@@ -426,6 +449,19 @@ export default function HomeScreen() {
   useEffect(() => {
     startRef.current = start;
   });
+
+  useEffect(() => {
+    initTimerNotification();
+    registerTimerActionHandler({
+      onStart: () => startRef.current(),
+      onPause: stop,
+      onReset: reset,
+    });
+    return () => {
+      unregisterTimerActionHandler();
+      clearTimerNotification();
+    };
+  }, []);
 
   // カウントダウンを停止
   const stop = () => {
@@ -443,6 +479,22 @@ export default function HomeScreen() {
     notifySoundRef.current?.stopAsync().catch(() => {});
     setSoundPlaying(false);
     setShowReset(true);
+    updateTimerNotification(
+      selectedSet ? selectedSet.name : '"クイックタイマー"',
+      selectedSet ? selectedSet.timers[indexRef.current]?.label ?? '' : '',
+      remaining,
+    );
+  };
+
+  const switchToNotification = () => {
+    const setName = selectedSet ? selectedSet.name : '"クイックタイマー"';
+    const timerName = selectedSet
+      ? selectedSet.timers[indexRef.current]?.label ?? ''
+      : '';
+    updateTimerNotification(setName, timerName, remaining);
+    if (Platform.OS === 'android') {
+      IntentLauncher.startActivityAsync(IntentLauncher.ActivityAction.HOME).catch(() => {});
+    }
   };
 
   // 実行中のタイマーや入力値をリセット
@@ -471,6 +523,7 @@ export default function HomeScreen() {
       setQuickDigits('');
       setQuickInitial(0);
     }
+    clearTimerNotification();
   };
 
 
@@ -546,20 +599,22 @@ export default function HomeScreen() {
         setRunCount(0);
         setTotalSec(0);
       }
+      clearTimerNotification();
     }
   };
 
   useEffect(() => {
     if (remaining === 0 && running) {
-      if (selectedSet) {
-        endOne();
-      } else {
-        setRunning(false);
-        soundRef.current?.replayAsync().catch(() => {});
-        setShowReset(true);
-      }
+    if (selectedSet) {
+      endOne();
+    } else {
+      setRunning(false);
+      soundRef.current?.replayAsync().catch(() => {});
+      setShowReset(true);
+      clearTimerNotification();
     }
-  }, [remaining, running, selectedSet]);
+  }
+}, [remaining, running, selectedSet]);
 
   return (
     <>
@@ -575,6 +630,9 @@ export default function HomeScreen() {
         </View>
 
         <View style={[styles.card, styles.timerCard]}>
+          <Pressable style={styles.notificationBtn} onPress={switchToNotification}>
+            <Ionicons name="open-outline" size={20} color={Colors.text} />
+          </Pressable>
           {selectedSet ? (
             <>
               <Text style={styles.infoText}>{`タイマーセット名：${selectedSet.name}`}</Text>
@@ -877,6 +935,12 @@ const styles = StyleSheet.create({
   modalTimerText: { color: Colors.subText, fontSize: 12 },
   modalTitle: { fontSize: 16, fontWeight: '700', color: Colors.text, marginBottom: 12, textAlign: 'center' },
   hiddenInput: { height: 0, width: 0 },
+  notificationBtn: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    padding: 4,
+  },
   timerCard: { marginTop: 20, alignItems: 'center', flex: 1 },
 });
 

--- a/src/utils/timerNotification.ts
+++ b/src/utils/timerNotification.ts
@@ -1,0 +1,105 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { formatHMS } from './format';
+
+// Manage showing a single persistent notification with timer controls.
+
+let currentNotificationId: string | null = null;
+let responseSub: Notifications.Subscription | null = null;
+
+/**
+ * Ensure notification channel (Android) and category with actions are set up.
+ */
+export const initTimerNotification = async (): Promise<void> => {
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('timer', {
+      name: 'Timer',
+      importance: Notifications.AndroidImportance.HIGH,
+      bypassDnd: true,
+      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+    });
+  }
+
+  await Notifications.requestPermissionsAsync();
+
+  await Notifications.setNotificationCategoryAsync('TIMER_CONTROLS', [
+    { identifier: 'START', buttonTitle: '開始' },
+    { identifier: 'PAUSE', buttonTitle: '停止' },
+    { identifier: 'RESET', buttonTitle: 'リセット', options: { isDestructive: true } },
+  ]);
+};
+
+type Handlers = {
+  onStart: () => void;
+  onPause: () => void;
+  onReset: () => void;
+};
+
+/**
+ * Listen for notification action presses and invoke the provided callbacks.
+ */
+export const registerTimerActionHandler = (handlers: Handlers): void => {
+  responseSub = Notifications.addNotificationResponseReceivedListener((resp) => {
+    const action = resp.actionIdentifier;
+    if (action === 'START') handlers.onStart();
+    if (action === 'PAUSE') handlers.onPause();
+    if (action === 'RESET') handlers.onReset();
+  });
+};
+
+/**
+ * Remove notification action listener.
+ */
+export const unregisterTimerActionHandler = (): void => {
+  responseSub?.remove();
+  responseSub = null;
+};
+
+/**
+ * Show or update the persistent timer notification.
+ * @param setName Name of the timer set
+ * @param timerName Name of the current timer
+ * @param remainingSec Remaining seconds for the timer
+ */
+export const updateTimerNotification = async (
+  setName: string,
+  timerName: string,
+  remainingSec: number,
+): Promise<void> => {
+  const body = `${timerName} 残り ${formatHMS(remainingSec)}`;
+
+  if (currentNotificationId) {
+    try {
+      await Notifications.dismissNotificationAsync(currentNotificationId);
+    } catch {}
+  }
+
+  currentNotificationId = await Notifications.scheduleNotificationAsync({
+    content: {
+      title: setName,
+      body,
+      categoryIdentifier: 'TIMER_CONTROLS',
+      sound: null,
+      android: {
+        channelId: 'timer',
+        priority: Notifications.AndroidNotificationPriority.MAX,
+        sticky: true,
+        color: '#2196f3',
+      },
+    },
+    trigger: null,
+  });
+};
+
+/**
+ * Clear the persistent timer notification if present.
+ */
+export const clearTimerNotification = async (): Promise<void> => {
+  if (currentNotificationId) {
+    try {
+      await Notifications.dismissNotificationAsync(currentNotificationId);
+    } catch {}
+    currentNotificationId = null;
+  }
+};
+


### PR DESCRIPTION
## Summary
- add icon-only button on home timer to launch media-style notification and return to device home
- update timer notifications each second and handle start/pause/reset actions
- include expo-intent-launcher dependency for Android home intent

## Testing
- `npm run lint`
- `bash gradlew assembleDebug` *(fails: Unable to tunnel through proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4482a502c832a8e218fc4e1155e76