### PR TITLE
Handle web notification unavailability

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -18,7 +18,6 @@ import { Ionicons } from '@expo/vector-icons';
 import Svg, { Circle, G } from 'react-native-svg';
 import { SOUND_OPTIONS, SOUND_FILES } from '../constants/sounds';
 import { Audio } from 'expo-av';
-import * as IntentLauncher from 'expo-intent-launcher';
 import {
   initTimerNotification,
   registerTimerActionHandler,
@@ -486,16 +485,20 @@ export default function HomeScreen() {
     );
   };
 
-  const switchToNotification = () => {
+  const switchToNotification = async () => {
     const setName = selectedSet ? selectedSet.name : '"クイックタイマー"';
     const timerName = selectedSet
       ? selectedSet.timers[indexRef.current]?.label ?? ''
       : '';
-    updateTimerNotification(setName, timerName, remaining);
+    try {
+      await updateTimerNotification(setName, timerName, remaining);
+    } catch (e) {
+      console.warn('Failed to update notification', e);
+    }
     if (Platform.OS === 'android') {
       try {
         const IntentLauncher = require('expo-intent-launcher') as typeof import('expo-intent-launcher');
-        IntentLauncher.startActivityAsync(IntentLauncher.ActivityAction.MAIN, {
+        await IntentLauncher.startActivityAsync(IntentLauncher.ActivityAction.MAIN, {
           category: IntentLauncher.ActivityCategory.HOME,
         });
       } catch (e) {

--- a/src/utils/timerNotification.ts
+++ b/src/utils/timerNotification.ts
@@ -11,6 +11,10 @@ let responseSub: Notifications.Subscription | null = null;
  * Ensure notification channel (Android) and category with actions are set up.
  */
 export const initTimerNotification = async (): Promise<void> => {
+  if (Platform.OS === 'web') {
+    return;
+  }
+
   if (Platform.OS === 'android') {
     await Notifications.setNotificationChannelAsync('timer', {
       name: 'Timer',
@@ -39,6 +43,8 @@ type Handlers = {
  * Listen for notification action presses and invoke the provided callbacks.
  */
 export const registerTimerActionHandler = (handlers: Handlers): void => {
+  if (Platform.OS === 'web') return;
+
   responseSub = Notifications.addNotificationResponseReceivedListener((resp) => {
     const action = resp.actionIdentifier;
     if (action === 'START') handlers.onStart();
@@ -51,6 +57,8 @@ export const registerTimerActionHandler = (handlers: Handlers): void => {
  * Remove notification action listener.
  */
 export const unregisterTimerActionHandler = (): void => {
+  if (Platform.OS === 'web') return;
+
   responseSub?.remove();
   responseSub = null;
 };
@@ -66,6 +74,10 @@ export const updateTimerNotification = async (
   timerName: string,
   remainingSec: number,
 ): Promise<void> => {
+  if (Platform.OS === 'web') {
+    return;
+  }
+
   const body = `${timerName} 残り ${formatHMS(remainingSec)}`;
 
   if (currentNotificationId) {
@@ -95,6 +107,10 @@ export const updateTimerNotification = async (
  * Clear the persistent timer notification if present.
  */
 export const clearTimerNotification = async (): Promise<void> => {
+  if (Platform.OS === 'web') {
+    return;
+  }
+
   if (currentNotificationId) {
     try {
       await Notifications.dismissNotificationAsync(currentNotificationId);


### PR DESCRIPTION
## Summary
- Skip native notification APIs on web to prevent `UnavailabilityError`
- Await notification scheduling before launching home screen and catch errors when switching to media style notification

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68b45c987140832a8d1550a94472cc3a