### PR TITLE
バックグラウンドで各タイマー終了を通知する

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
 import dayjs from 'dayjs';
+import { Platform } from 'react-native';
 import { Timer, TimerSet, NotificationConfig, RepeatIntervalUnit } from '../context/TimerContext';
 
 // Expo の通知機能を用いてタイマー終了や予約通知をスケジュールするためのヘルパー群
@@ -43,22 +44,38 @@ export const scheduleEndNotification = async (
   sec: number,
   timer?: Timer,
   withSound: boolean = true,
-): Promise<void> => {
+): Promise<string | null> => {
   try {
-    await Notifications.requestPermissionsAsync();
-    await Notifications.scheduleNotificationAsync({
+    if (!(await ensurePermissions())) return null;
+
+    if (Platform.OS === 'android') {
+      await Notifications.setNotificationChannelAsync('timer', {
+        name: 'Timer',
+        importance: Notifications.AndroidImportance.HIGH,
+        bypassDnd: true,
+        lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+      });
+    }
+
+    const id = await Notifications.scheduleNotificationAsync({
       content: {
         title: 'タイマー終了',
         body: `${timer?.label ?? 'タイマー'} が終了しました`,
         sound: withSound ? true : undefined,
-      },
+        android: {
+          channelId: 'timer',
+          priority: Notifications.AndroidNotificationPriority.MAX,
+        },
+      } as any,
       trigger: {
         seconds: sec,
         type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
-      }
+      },
     });
-  } catch(e) {
+    return id;
+  } catch (e) {
     console.warn('Notification schedule failed', e);
+    return null;
   }
 };
 


### PR DESCRIPTION
## Summary
- タイマーセットの通知設定に依存せず、全タイマーの終了通知を予約するよう修正しました
- Androidの高優先度チャンネルを使用してバナー通知が確実に表示されるようにしました

## Testing
- `npm test` (Missing script: "test")
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bad5987c28832aa1398d1d01162833