### PR TITLE
fix: avoid null sound in notifications

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -57,16 +57,21 @@ export const scheduleEndNotification = async (
       });
     }
 
+    const content: Notifications.NotificationContentInput = {
+      title: 'タイマー終了',
+      body: `${timer?.label ?? 'タイマー'} が終了しました`,
+      android: {
+        channelId: 'timer',
+        priority: Notifications.AndroidNotificationPriority.MAX,
+      },
+    } as any;
+
+    if (withSound) {
+      (content as any).sound = true;
+    }
+
     const id = await Notifications.scheduleNotificationAsync({
-      content: {
-        title: 'タイマー終了',
-        body: `${timer?.label ?? 'タイマー'} が終了しました`,
-        sound: withSound ? true : undefined,
-        android: {
-          channelId: 'timer',
-          priority: Notifications.AndroidNotificationPriority.MAX,
-        },
-      } as any,
+      content,
       trigger: {
         seconds: sec,
         type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,

--- a/src/utils/timerNotification.ts
+++ b/src/utils/timerNotification.ts
@@ -91,7 +91,7 @@ export const updateTimerNotification = async (
       title: setName,
       body,
       categoryIdentifier: 'TIMER_CONTROLS',
-      sound: null,
+      sound: false,
       android: {
         channelId: 'timer',
         priority: Notifications.AndroidNotificationPriority.MAX,


### PR DESCRIPTION
## Summary
- avoid passing undefined sound when scheduling timer end notifications
- set persistent timer notification sound to false

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Parameter 'v' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe9ca4d18832ab3c479ee14d7aac1