### PR TITLE
fix: sync timers after background resume

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -76,6 +76,7 @@ export default function HomeScreen() {
 
   const elapsedRef = useRef(0);
   const lastUpdateRef = useRef(Date.now());
+  const runStartRef = useRef<number | null>(null);
   const selectedSet = useMemo(
     () => state.timerSets.find(s => s.id === selectedId) ?? null,
     [selectedId, state.timerSets]
@@ -114,6 +115,95 @@ export default function HomeScreen() {
   }, [historyId, totalSec, runCount]);
 
   useEffect(() => {
+    const handleActive = () => {
+      if (!runningRef.current || runStartRef.current == null) return;
+      const now = Date.now();
+      let elapsedSec = (now - runStartRef.current) / 1000;
+
+      if (selectedSet) {
+        const durations = selectedSet.timers.map(t => getDuration(t));
+        const total = durations.reduce((sum, d) => sum + d, 0);
+        if (elapsedSec >= total) {
+          // セット全体が終了している場合
+          setIndex(durations.length - 1);
+          indexRef.current = durations.length - 1;
+          setRemaining(0);
+          remainingRef.current = 0;
+          endTimeRef.current = null;
+          runStartRef.current = null;
+          setRunning(false);
+          runningRef.current = false;
+          setShowReset(true);
+          updateTimerNotification(
+            selectedSet.name,
+            selectedSet.timers[durations.length - 1]?.label ?? '',
+            0,
+          );
+          clearTimerNotification();
+          cancelTimerSetNotification(scheduledIdsRef.current);
+          scheduledIdsRef.current = [];
+          if (historyId) {
+            dispatch({
+              type: 'LOG_COMPLETE',
+              payload: {
+                id: historyId,
+                totalDurationSec: total,
+                timersRun: durations.length,
+              },
+            });
+            setHistoryId(null);
+            setRunCount(durations.length);
+            setTotalSec(total);
+          }
+          return;
+        }
+
+        // 経過時間から現在のタイマーと残り時間を算出
+        let idx = 0;
+        let past = 0;
+        while (idx < durations.length && elapsedSec >= durations[idx]) {
+          elapsedSec -= durations[idx];
+          past += durations[idx];
+          idx++;
+        }
+        const remain = Math.max(0, Math.round(durations[idx] - elapsedSec));
+        setIndex(idx);
+        indexRef.current = idx;
+        setRemaining(remain);
+        remainingRef.current = remain;
+        endTimeRef.current = now + remain * 1000;
+        lastUpdateRef.current = now;
+        elapsedRef.current = past + (durations[idx] - remain);
+        setRunCount(idx);
+        setTotalSec(past);
+        updateTimerNotification(
+          selectedSet.name,
+          selectedSet.timers[idx]?.label ?? '',
+          remain,
+        );
+      } else {
+        const remain = Math.max(
+          0,
+          Math.round(quickInitial - elapsedSec),
+        );
+        setRemaining(remain);
+        remainingRef.current = remain;
+        if (remain <= 0) {
+          endTimeRef.current = null;
+          runStartRef.current = null;
+          setRunning(false);
+          runningRef.current = false;
+          setShowReset(true);
+          clearTimerNotification();
+        } else {
+          endTimeRef.current = now + remain * 1000;
+          lastUpdateRef.current = now;
+          elapsedRef.current = quickInitial - remain;
+          updateTimerNotification('"クイックタイマー"', '', remain);
+        }
+      }
+    };
+
     const sub = AppState.addEventListener('change', state => {
       if ((state === 'background' || state === 'inactive') && runningRef.current) {
         const setName = selectedSet ? selectedSet.name : '"クイックタイマー"';
@@ -121,22 +211,12 @@ export default function HomeScreen() {
           ? selectedSet.timers[indexRef.current]?.label ?? ''
           : '';
         updateTimerNotification(setName, timerName, remainingRef.current);
-      } else if (state === 'active' && runningRef.current && endTimeRef.current != null) {
-        const remain = Math.max(0, Math.round((endTimeRef.current - Date.now()) / 1000));
-        remainingRef.current = remain;
-        setRemaining(remain);
-        const setName = selectedSet ? selectedSet.name : '"クイックタイマー"';
-        const timerName = selectedSet
-          ? selectedSet.timers[indexRef.current]?.label ?? ''
-          : '';
-        updateTimerNotification(setName, timerName, remain);
-        if (remain <= 0 && selectedSet) {
-          endOne();
-        }
+      } else if (state === 'active') {
+        handleActive();
       }
     });
     return () => sub.remove();
-  }, [selectedSet]);
+  }, [selectedSet, historyId, dispatch]);
 
   const totalDuration = useMemo(() => {
     if (selectedSet) {
@@ -353,6 +433,7 @@ export default function HomeScreen() {
       }
       cancelTimerSetNotification(scheduledIdsRef.current);
       scheduledIdsRef.current = [];
+      runStartRef.current = null;
     };
   }, [dispatch]);
 
@@ -445,6 +526,9 @@ export default function HomeScreen() {
     let rem = Number.isFinite(init ?? remaining) ? Math.max(0, init ?? remaining) : 0;
     soundRef.current?.stopAsync().catch(() => {});
     setSoundPlaying(false);
+    if (runStartRef.current == null) {
+      runStartRef.current = Date.now() - elapsedRef.current * 1000;
+    }
     if (selectedSet && !historyId) {
       const id = uuidv4();
       dispatch({ type: 'LOG_START', payload: { id, timerSetId: selectedSet.id } });
@@ -520,9 +604,11 @@ export default function HomeScreen() {
     });
     return () => {
       unregisterTimerActionHandler();
-      clearTimerNotification();
-      cancelTimerSetNotification(scheduledIdsRef.current);
-      scheduledIdsRef.current = [];
+      if (!runningRef.current) {
+        clearTimerNotification();
+        cancelTimerSetNotification(scheduledIdsRef.current);
+        scheduledIdsRef.current = [];
+      }
     };
   }, []);
 
@@ -537,6 +623,7 @@ export default function HomeScreen() {
       nextTimeoutRef.current = null;
     }
     endTimeRef.current = null;
+    runStartRef.current = null;
     setRunning(false);
     soundRef.current?.stopAsync().catch(() => {});
     notifySoundRef.current?.stopAsync().catch(() => {});
@@ -658,21 +745,23 @@ export default function HomeScreen() {
       clearTimerNotification();
       cancelTimerSetNotification(scheduledIdsRef.current);
       scheduledIdsRef.current = [];
+      runStartRef.current = null;
     }
   };
 
   useEffect(() => {
     if (remaining === 0 && running) {
-    if (selectedSet) {
-      endOne();
-    } else {
-      setRunning(false);
-      soundRef.current?.replayAsync().catch(() => {});
-      setShowReset(true);
-      clearTimerNotification();
+      if (selectedSet) {
+        endOne();
+      } else {
+        setRunning(false);
+        soundRef.current?.replayAsync().catch(() => {});
+        setShowReset(true);
+        clearTimerNotification();
+        runStartRef.current = null;
+      }
     }
-  }
-}, [remaining, running, selectedSet]);
+  }, [remaining, running, selectedSet]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- track run start time to calculate elapsed across background periods
- recompute active timer and remaining time on app resume
- clear start timestamp when stopping or completing timer sets
- preserve timer notifications while running so navigating away doesn't end the set

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bc08feff20832a8e899728df25e3fb